### PR TITLE
GraphicsMagick initialisation, refactor DAC for multi chip support

### DIFF
--- a/tpx3App/Db/Chips.template
+++ b/tpx3App/Db/Chips.template
@@ -24,103 +24,103 @@
 
 record(longin, "$(P)$(R)$(C)_CP_PLL_RBV"){
   field(DTYP, "asynInt32")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_CP_PLL")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_CP_PLL")
   field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)$(C)_S1_OFF_RBV"){
   field(DTYP, "asynInt32")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_DISCS1OFF")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_DISCS1OFF")
   field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)$(C)_S1_ON_RBV"){
   field(DTYP, "asynInt32")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_DISCS1ON")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_DISCS1ON")
   field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)$(C)_S2_OFF_RBV"){
   field(DTYP, "asynInt32")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_DISCS2OFF")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_DISCS2OFF")
   field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)$(C)_S2_ON_RBV"){
   field(DTYP, "asynInt32")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_DISCS2ON")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_DISCS2ON")
   field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)$(C)_Ikrum_RBV"){
   field(DTYP, "asynInt32")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_IKRUM")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_IKRUM")
   field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)$(C)_PixelDAC_RBV"){
   field(DTYP, "asynInt32")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_PIXELDAC")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_PIXELDAC")
   field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)$(C)_Preamp_OFF_RBV"){
   field(DTYP, "asynInt32")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_PREAMPOFF")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_PREAMPOFF")
   field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)$(C)_Preamp_ON_RBV"){
   field(DTYP, "asynInt32")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_PREAMPON")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_PREAMPON")
   field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)$(C)_TPbufferIn_RBV"){
   field(DTYP, "asynInt32")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_TPBUFFERIN")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_TPBUFFERIN")
   field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)$(C)_TPbufferOut_RBV"){
   field(DTYP, "asynInt32")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_TPBUFFEROUT")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_TPBUFFEROUT")
   field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)$(C)_PLL_Vcntrl_RBV"){
   field(DTYP, "asynInt32")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_PLL_VCNTRL")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_PLL_VCNTRL")
   field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)$(C)_VPreamp_NCAS_RBV"){
   field(DTYP, "asynInt32")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_VPREAMPNCAS")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_VPREAMPNCAS")
   field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)$(C)_VTP_coarse_RBV"){
   field(DTYP, "asynInt32")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_VTP_COARSE")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_VTP_COARSE")
   field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)$(C)_VTP_fine_RBV"){
   field(DTYP, "asynInt32")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_VTP_FINE")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_VTP_FINE")
   field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)$(C)_Vfbk_RBV"){
   field(DTYP, "asynInt32")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_VFBK")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_VFBK")
   field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)$(C)_Vth_coarse_RBV"){
   field(DTYP, "asynInt32")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_VTH_COARSE")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_VTH_COARSE")
   field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)$(C)_Vth_fine_RBV"){
   field(DTYP, "asynInt32")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_VTH_FINE")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_VTH_FINE")
   field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)$(C)_Adjust_RBV"){
   field(DTYP, "asynInt32")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_ADJUST")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_ADJUST")
   field(SCAN, "I/O Intr")
 }
 
 # Detector Chip Layout
 record(stringin, "$(P)$(R)$(C)_Layout_RBV"){
   field(DTYP, "asynOctetRead")
-  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_$(C)_LAYTOUT")
+  field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_LAYTOUT")
   field(SCAN, "I/O Intr")
 }

--- a/tpx3App/Db/Chips.template
+++ b/tpx3App/Db/Chips.template
@@ -102,11 +102,23 @@ record(longin, "$(P)$(R)$(C)_Vfbk_RBV"){
   field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_VFBK")
   field(SCAN, "I/O Intr")
 }
+
+record(longout, "$(P)$(R)$(C)_Vth_coarse"){
+    field(DTYP, "asynInt32")
+    field(OUT, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_VTH_COARSE")
+}
+
 record(longin, "$(P)$(R)$(C)_Vth_coarse_RBV"){
   field(DTYP, "asynInt32")
   field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_VTH_COARSE")
   field(SCAN, "I/O Intr")
 }
+
+record(longout, "$(P)$(R)$(C)_Vth_fine"){
+    field(DTYP, "asynInt32")
+    field(OUT, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_VTH_FINE")
+}
+
 record(longin, "$(P)$(R)$(C)_Vth_fine_RBV"){
   field(DTYP, "asynInt32")
   field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))TPX3_VTH_FINE")

--- a/tpx3App/Db/File.template
+++ b/tpx3App/Db/File.template
@@ -131,7 +131,7 @@ record(waveform, "$(P)$(R)WriteFileMessage")
     field(SCAN, "I/O Intr")
 }
 
-record(mbbo, "$(P)$(R)RawStream")
+record(mbbi, "$(P)$(R)RawStream")
 {
    field(DTYP, "asynInt32")
    field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))TPX3_RAW_STREAM")

--- a/tpx3App/src/ADTimePix.cpp
+++ b/tpx3App/src/ADTimePix.cpp
@@ -1810,6 +1810,8 @@ ADTimePix::ADTimePix(const char* portName, const char* serverURL, int maxBuffers
     : ADDriver(portName, 1, (int)NUM_TIMEPIX_PARAMS, maxBuffers, maxMemory, asynInt64Mask | asynEnumMask, asynInt64Mask | asynEnumMask, ASYN_CANBLOCK, 1, priority, stackSize){
     static const char* functionName = "ADTimePix";
 
+    /* Initialize GraphicsMagick */
+    InitializeMagick(NULL);
 
     this->serverURL = string(serverURL);
 

--- a/tpx3App/src/ADTimePix.cpp
+++ b/tpx3App/src/ADTimePix.cpp
@@ -566,6 +566,48 @@ asynStatus ADTimePix::getHealth(){
     return status;
 }
 
+/**
+ * Fetch DACs values and update PVs readback
+ *
+ * data:      Json Data (json)
+ * chip:      Number of the chip (int)
+ *
+ * @return: status
+*/
+
+asynStatus ADTimePix::fecthDacs(json& data, int chip) {
+    setIntegerParam(chip, ADTimePixCP_PLL,             data["Chips"][chip]["DACs"]["Ibias_CP_PLL"].get<int>());
+    setIntegerParam(chip, ADTimePixDiscS1OFF,          data["Chips"][chip]["DACs"]["Ibias_DiscS1_OFF"].get<int>());
+    setIntegerParam(chip, ADTimePixDiscS1ON,           data["Chips"][chip]["DACs"]["Ibias_DiscS1_ON"].get<int>());
+    setIntegerParam(chip, ADTimePixDiscS2OFF,          data["Chips"][chip]["DACs"]["Ibias_DiscS2_OFF"].get<int>());
+    setIntegerParam(chip, ADTimePixDiscS2ON,           data["Chips"][chip]["DACs"]["Ibias_DiscS2_ON"].get<int>());
+    setIntegerParam(chip, ADTimePixIkrum,              data["Chips"][chip]["DACs"]["Ibias_Ikrum"].get<int>());
+    setIntegerParam(chip, ADTimePixPixelDAC,           data["Chips"][chip]["DACs"]["Ibias_PixelDAC"].get<int>());
+    setIntegerParam(chip, ADTimePixPreampOFF,          data["Chips"][chip]["DACs"]["Ibias_Preamp_OFF"].get<int>());
+    setIntegerParam(chip, ADTimePixPreampON,           data["Chips"][chip]["DACs"]["Ibias_Preamp_ON"].get<int>());
+    setIntegerParam(chip, ADTimePixTPbufferIn,         data["Chips"][chip]["DACs"]["Ibias_TPbufferIn"].get<int>());
+    setIntegerParam(chip, ADTimePixTPbufferOut,        data["Chips"][chip]["DACs"]["Ibias_TPbufferOut"].get<int>());
+    setIntegerParam(chip, ADTimePixPLL_Vcntrl,         data["Chips"][chip]["DACs"]["PLL_Vcntrl"].get<int>());
+    setIntegerParam(chip, ADTimePixVPreampNCAS,        data["Chips"][chip]["DACs"]["VPreamp_NCAS"].get<int>());
+    setIntegerParam(chip, ADTimePixVTPcoarse,          data["Chips"][chip]["DACs"]["VTP_coarse"].get<int>());
+    setIntegerParam(chip, ADTimePixVTPfine,            data["Chips"][chip]["DACs"]["VTP_fine"].get<int>());
+    setIntegerParam(chip, ADTimePixVfbk,               data["Chips"][chip]["DACs"]["Vfbk"].get<int>());
+    setIntegerParam(chip, ADTimePixVthresholdCoarse,   data["Chips"][chip]["DACs"]["Vthreshold_coarse"].get<int>());
+    setIntegerParam(chip, ADTimePixVTthresholdFine,    data["Chips"][chip]["DACs"]["Vthreshold_fine"].get<int>());
+
+    if (data["Chips"][chip]["Adjust"].is_null()) {
+        setIntegerParam(chip, ADTimePixAdjust, -1);
+    }
+    else if (data["Chips"][chip]["Adjust"].is_number_integer()) {
+        setIntegerParam(chip, ADTimePixAdjust, data["Chips"][chip]["Adjust"].get<int>());
+    }
+    else {
+        setIntegerParam(chip, ADTimePixAdjust, -2);
+    }
+
+    return asynSuccess;
+}
+
 asynStatus ADTimePix::getDetector(){
     const char* functionName = "getDetector";
     asynStatus status = asynSuccess;
@@ -651,141 +693,23 @@ asynStatus ADTimePix::getDetector(){
     setIntegerParam(ADTimePixLogLevel,               detector_j["Config"]["LogLevel"].get<int>());
 
     // Detector Chips: Chip0
-    setIntegerParam(ADTimePixChip0CP_PLL,             detector_j["Chips"][0]["DACs"]["Ibias_CP_PLL"].get<int>());
-    setIntegerParam(ADTimePixChip0DiscS1OFF,          detector_j["Chips"][0]["DACs"]["Ibias_DiscS1_OFF"].get<int>());
-    setIntegerParam(ADTimePixChip0DiscS1ON,           detector_j["Chips"][0]["DACs"]["Ibias_DiscS1_ON"].get<int>());
-    setIntegerParam(ADTimePixChip0DiscS2OFF,          detector_j["Chips"][0]["DACs"]["Ibias_DiscS2_OFF"].get<int>());
-    setIntegerParam(ADTimePixChip0DiscS2ON,           detector_j["Chips"][0]["DACs"]["Ibias_DiscS2_ON"].get<int>());
-    setIntegerParam(ADTimePixChip0Ikrum,              detector_j["Chips"][0]["DACs"]["Ibias_Ikrum"].get<int>());
-    setIntegerParam(ADTimePixChip0PixelDAC,           detector_j["Chips"][0]["DACs"]["Ibias_PixelDAC"].get<int>());
-    setIntegerParam(ADTimePixChip0PreampOFF,          detector_j["Chips"][0]["DACs"]["Ibias_Preamp_OFF"].get<int>());
-    setIntegerParam(ADTimePixChip0PreampON,           detector_j["Chips"][0]["DACs"]["Ibias_Preamp_ON"].get<int>());
-    setIntegerParam(ADTimePixChip0TPbufferIn,         detector_j["Chips"][0]["DACs"]["Ibias_TPbufferIn"].get<int>());
-    setIntegerParam(ADTimePixChip0TPbufferOut,        detector_j["Chips"][0]["DACs"]["Ibias_TPbufferOut"].get<int>());
-    setIntegerParam(ADTimePixChip0PLL_Vcntrl,         detector_j["Chips"][0]["DACs"]["PLL_Vcntrl"].get<int>());
-    setIntegerParam(ADTimePixChip0VPreampNCAS,        detector_j["Chips"][0]["DACs"]["VPreamp_NCAS"].get<int>());
-    setIntegerParam(ADTimePixChip0VTPcoarse,          detector_j["Chips"][0]["DACs"]["VTP_coarse"].get<int>());
-    setIntegerParam(ADTimePixChip0VTPfine,            detector_j["Chips"][0]["DACs"]["VTP_fine"].get<int>());
-    setIntegerParam(ADTimePixChip0Vfbk,               detector_j["Chips"][0]["DACs"]["Vfbk"].get<int>());
-    setIntegerParam(ADTimePixChip0VthresholdCoarse,   detector_j["Chips"][0]["DACs"]["Vthreshold_coarse"].get<int>());
-    setIntegerParam(ADTimePixChip0VTthresholdFine,    detector_j["Chips"][0]["DACs"]["Vthreshold_fine"].get<int>());
-    if (detector_j["Chips"][0]["Adjust"].is_null()) {
-        setIntegerParam(ADTimePixChip0Adjust,            -1 );
-    }   else if (detector_j["Chips"][0]["Adjust"].is_number_integer()) {
-        setIntegerParam(ADTimePixChip0Adjust,             detector_j["Chips"][0]["Adjust"].get<int>());
-    }   else {
-            setIntegerParam(ADTimePixChip0Adjust,            -2 );
-    }
-
-     // Serval3 - Detector Chip Layout
-    setStringParam(ADTimePixDetectorOrientation,     strip_quotes(detector_j["Layout"]["DetectorOrientation"].dump().c_str()));
-    setStringParam(ADTimePixChip0Layout,    detector_j["Layout"]["Original"]["Chips"][0].dump().c_str());   
-
-    if (detector_j["Info"]["NumberOfChips"].get<int>() >= 2) {
-        // Detector Chips: Chip1
-        setIntegerParam(ADTimePixChip1CP_PLL,             detector_j["Chips"][1]["DACs"]["Ibias_CP_PLL"].get<int>());
-        setIntegerParam(ADTimePixChip1DiscS1OFF,          detector_j["Chips"][1]["DACs"]["Ibias_DiscS1_OFF"].get<int>());
-        setIntegerParam(ADTimePixChip1DiscS1ON,           detector_j["Chips"][1]["DACs"]["Ibias_DiscS1_ON"].get<int>());
-        setIntegerParam(ADTimePixChip1DiscS2OFF,          detector_j["Chips"][1]["DACs"]["Ibias_DiscS2_OFF"].get<int>());
-        setIntegerParam(ADTimePixChip1DiscS2ON,           detector_j["Chips"][1]["DACs"]["Ibias_DiscS2_ON"].get<int>());
-        setIntegerParam(ADTimePixChip1Ikrum,              detector_j["Chips"][1]["DACs"]["Ibias_Ikrum"].get<int>());
-        setIntegerParam(ADTimePixChip1PixelDAC,           detector_j["Chips"][1]["DACs"]["Ibias_PixelDAC"].get<int>());
-        setIntegerParam(ADTimePixChip1PreampOFF,          detector_j["Chips"][1]["DACs"]["Ibias_Preamp_OFF"].get<int>());
-        setIntegerParam(ADTimePixChip1PreampON,           detector_j["Chips"][1]["DACs"]["Ibias_Preamp_ON"].get<int>());
-        setIntegerParam(ADTimePixChip1TPbufferIn,         detector_j["Chips"][1]["DACs"]["Ibias_TPbufferIn"].get<int>());
-        setIntegerParam(ADTimePixChip1TPbufferOut,        detector_j["Chips"][1]["DACs"]["Ibias_TPbufferOut"].get<int>());
-        setIntegerParam(ADTimePixChip1PLL_Vcntrl,         detector_j["Chips"][1]["DACs"]["PLL_Vcntrl"].get<int>());
-        setIntegerParam(ADTimePixChip1VPreampNCAS,        detector_j["Chips"][1]["DACs"]["VPreamp_NCAS"].get<int>());
-        setIntegerParam(ADTimePixChip1VTPcoarse,          detector_j["Chips"][1]["DACs"]["VTP_coarse"].get<int>());
-        setIntegerParam(ADTimePixChip1VTPfine,            detector_j["Chips"][1]["DACs"]["VTP_fine"].get<int>());
-        setIntegerParam(ADTimePixChip1Vfbk,               detector_j["Chips"][1]["DACs"]["Vfbk"].get<int>());
-        setIntegerParam(ADTimePixChip1VthresholdCoarse,   detector_j["Chips"][1]["DACs"]["Vthreshold_coarse"].get<int>());
-        setIntegerParam(ADTimePixChip1VTthresholdFine,    detector_j["Chips"][1]["DACs"]["Vthreshold_fine"].get<int>());
-        if (detector_j["Chips"][1]["Adjust"].is_null()) {
-            setIntegerParam(ADTimePixChip1Adjust,            -1 );
-        }   else if (detector_j["Chips"][1]["Adjust"].is_number_integer()) {
-            setIntegerParam(ADTimePixChip1Adjust,             detector_j["Chips"][1]["Adjust"].get<int>());
-        }   else {
-            setIntegerParam(ADTimePixChip1Adjust,            -2 );
-        }
-        setStringParam(ADTimePixChip1Layout,    detector_j["Layout"]["Original"]["Chips"][1].dump().c_str());
-    }
-
-    if (detector_j["Info"]["NumberOfChips"].get<int>() >= 3) {
-        // Detector Chips: Chip2
-        setIntegerParam(ADTimePixChip2CP_PLL,             detector_j["Chips"][2]["DACs"]["Ibias_CP_PLL"].get<int>());
-        setIntegerParam(ADTimePixChip2DiscS1OFF,          detector_j["Chips"][2]["DACs"]["Ibias_DiscS1_OFF"].get<int>());
-        setIntegerParam(ADTimePixChip2DiscS1ON,           detector_j["Chips"][2]["DACs"]["Ibias_DiscS1_ON"].get<int>());
-        setIntegerParam(ADTimePixChip2DiscS2OFF,          detector_j["Chips"][2]["DACs"]["Ibias_DiscS2_OFF"].get<int>());
-        setIntegerParam(ADTimePixChip2DiscS2ON,           detector_j["Chips"][2]["DACs"]["Ibias_DiscS2_ON"].get<int>());
-        setIntegerParam(ADTimePixChip2Ikrum,              detector_j["Chips"][2]["DACs"]["Ibias_Ikrum"].get<int>());
-        setIntegerParam(ADTimePixChip2PixelDAC,           detector_j["Chips"][2]["DACs"]["Ibias_PixelDAC"].get<int>());
-        setIntegerParam(ADTimePixChip2PreampOFF,          detector_j["Chips"][2]["DACs"]["Ibias_Preamp_OFF"].get<int>());
-        setIntegerParam(ADTimePixChip2PreampON,           detector_j["Chips"][2]["DACs"]["Ibias_Preamp_ON"].get<int>());
-        setIntegerParam(ADTimePixChip2TPbufferIn,         detector_j["Chips"][2]["DACs"]["Ibias_TPbufferIn"].get<int>());
-        setIntegerParam(ADTimePixChip2TPbufferOut,        detector_j["Chips"][2]["DACs"]["Ibias_TPbufferOut"].get<int>());
-        setIntegerParam(ADTimePixChip2PLL_Vcntrl,         detector_j["Chips"][2]["DACs"]["PLL_Vcntrl"].get<int>());
-        setIntegerParam(ADTimePixChip2VPreampNCAS,        detector_j["Chips"][2]["DACs"]["VPreamp_NCAS"].get<int>());
-        setIntegerParam(ADTimePixChip2VTPcoarse,          detector_j["Chips"][2]["DACs"]["VTP_coarse"].get<int>());
-        setIntegerParam(ADTimePixChip2VTPfine,            detector_j["Chips"][2]["DACs"]["VTP_fine"].get<int>());
-        setIntegerParam(ADTimePixChip2Vfbk,               detector_j["Chips"][2]["DACs"]["Vfbk"].get<int>());
-        setIntegerParam(ADTimePixChip2VthresholdCoarse,   detector_j["Chips"][2]["DACs"]["Vthreshold_coarse"].get<int>());
-        setIntegerParam(ADTimePixChip2VTthresholdFine,    detector_j["Chips"][2]["DACs"]["Vthreshold_fine"].get<int>());
-        if (detector_j["Chips"][2]["Adjust"].is_null()) {
-            setIntegerParam(ADTimePixChip2Adjust,            -1 );
-        }   else if (detector_j["Chips"][2]["Adjust"].is_number_integer()) {
-            setIntegerParam(ADTimePixChip2Adjust,             detector_j["Chips"][2]["Adjust"].get<int>());
-        }   else {
-            setIntegerParam(ADTimePixChip2Adjust,            -2 );
-        }
-        setStringParam(ADTimePixChip2Layout,    detector_j["Layout"]["Original"]["Chips"][2].dump().c_str());
-    }
-
-    if (detector_j["Info"]["NumberOfChips"].get<int>() >= 4) {
-        // Detector Chips: Chip3
-        setIntegerParam(ADTimePixChip3CP_PLL,             detector_j["Chips"][3]["DACs"]["Ibias_CP_PLL"].get<int>());
-        setIntegerParam(ADTimePixChip3DiscS1OFF,          detector_j["Chips"][3]["DACs"]["Ibias_DiscS1_OFF"].get<int>());
-        setIntegerParam(ADTimePixChip3DiscS1ON,           detector_j["Chips"][3]["DACs"]["Ibias_DiscS1_ON"].get<int>());
-        setIntegerParam(ADTimePixChip3DiscS2OFF,          detector_j["Chips"][3]["DACs"]["Ibias_DiscS2_OFF"].get<int>());
-        setIntegerParam(ADTimePixChip3DiscS2ON,           detector_j["Chips"][3]["DACs"]["Ibias_DiscS2_ON"].get<int>());
-        setIntegerParam(ADTimePixChip3Ikrum,              detector_j["Chips"][3]["DACs"]["Ibias_Ikrum"].get<int>());
-        setIntegerParam(ADTimePixChip3PixelDAC,           detector_j["Chips"][3]["DACs"]["Ibias_PixelDAC"].get<int>());
-        setIntegerParam(ADTimePixChip3PreampOFF,          detector_j["Chips"][3]["DACs"]["Ibias_Preamp_OFF"].get<int>());
-        setIntegerParam(ADTimePixChip3PreampON,           detector_j["Chips"][3]["DACs"]["Ibias_Preamp_ON"].get<int>());
-        setIntegerParam(ADTimePixChip3TPbufferIn,         detector_j["Chips"][3]["DACs"]["Ibias_TPbufferIn"].get<int>());
-        setIntegerParam(ADTimePixChip3TPbufferOut,        detector_j["Chips"][3]["DACs"]["Ibias_TPbufferOut"].get<int>());
-        setIntegerParam(ADTimePixChip3PLL_Vcntrl,         detector_j["Chips"][3]["DACs"]["PLL_Vcntrl"].get<int>());
-        setIntegerParam(ADTimePixChip3VPreampNCAS,        detector_j["Chips"][3]["DACs"]["VPreamp_NCAS"].get<int>());
-        setIntegerParam(ADTimePixChip3VTPcoarse,          detector_j["Chips"][3]["DACs"]["VTP_coarse"].get<int>());
-        setIntegerParam(ADTimePixChip3VTPfine,            detector_j["Chips"][3]["DACs"]["VTP_fine"].get<int>());
-        setIntegerParam(ADTimePixChip3Vfbk,               detector_j["Chips"][3]["DACs"]["Vfbk"].get<int>());
-        setIntegerParam(ADTimePixChip3VthresholdCoarse,   detector_j["Chips"][3]["DACs"]["Vthreshold_coarse"].get<int>());
-        setIntegerParam(ADTimePixChip3VTthresholdFine,    detector_j["Chips"][3]["DACs"]["Vthreshold_fine"].get<int>());
-        if (detector_j["Chips"][3]["Adjust"].is_null()) {
-            setIntegerParam(ADTimePixChip3Adjust,            -1 );
-        }   else if (detector_j["Chips"][3]["Adjust"].is_number_integer()) {
-            setIntegerParam(ADTimePixChip3Adjust,             detector_j["Chips"][3]["Adjust"].get<int>());
-        }   else {
-            setIntegerParam(ADTimePixChip3Adjust,            -2 );
-        }
-        setStringParam(ADTimePixChip3Layout,    detector_j["Layout"]["Original"]["Chips"][3].dump().c_str()); 
-    }
-
-    // Serval2.3.6 Detector Chip Layout
-//    setStringParam(ADTimePixChip0Layout,    detector_j["Layout"][0].dump().c_str());
-//    setStringParam(ADTimePixChip1Layout,    detector_j["Layout"][1].dump().c_str());
-//    setStringParam(ADTimePixChip2Layout,    detector_j["Layout"][2].dump().c_str());
-//    setStringParam(ADTimePixChip3Layout,    detector_j["Layout"][3].dump().c_str());
+    fecthDacs(detector_j, 0);
 
     // Serval3 - Detector Chip Layout
-    // setStringParam(ADTimePixDetectorOrientation,     strip_quotes(detector_j["Layout"]["DetectorOrientation"].dump().c_str()));
-    // setStringParam(ADTimePixChip0Layout,    detector_j["Layout"]["Original"]["Chips"][0].dump().c_str());
-    // setStringParam(ADTimePixChip1Layout,    detector_j["Layout"]["Original"]["Chips"][1].dump().c_str());
-    // setStringParam(ADTimePixChip2Layout,    detector_j["Layout"]["Original"]["Chips"][2].dump().c_str());
-    // setStringParam(ADTimePixChip3Layout,    detector_j["Layout"]["Original"]["Chips"][3].dump().c_str());
-
-    // Refresh PV values
+    setStringParam(ADTimePixDetectorOrientation, strip_quotes(detector_j["Layout"]["DetectorOrientation"].dump().c_str()));
+    setStringParam(0, ADTimePixLayout, detector_j["Layout"]["Original"]["Chips"][0].dump().c_str());
     callParamCallbacks();
+
+    int number_chips = detector_j["Info"]["NumberOfChips"].get<int>();
+    for (int chip = 1; chip < number_chips; chip++) {
+        fecthDacs(detector_j, 1);
+        setStringParam(
+            chip,
+            ADTimePixLayout,
+            detector_j["Layout"]["Original"]["Chips"][chip].dump().c_str()
+        );
+        callParamCallbacks(chip);
+    }
 
     return status;
 }
@@ -1806,8 +1730,15 @@ asynStatus ADTimePix::readImage()
 // ADTimePix Constructor/Destructor
 //----------------------------------------------------------------------------
 
-ADTimePix::ADTimePix(const char* portName, const char* serverURL, int maxBuffers, size_t maxMemory, int priority, int stackSize )
-    : ADDriver(portName, 1, (int)NUM_TIMEPIX_PARAMS, maxBuffers, maxMemory, asynInt64Mask | asynEnumMask, asynInt64Mask | asynEnumMask, ASYN_CANBLOCK, 1, priority, stackSize){
+ADTimePix::ADTimePix(const char* portName, const char* serverURL, int maxBuffers, size_t maxMemory, int priority, int stackSize)
+    : ADDriver(portName, 4, (int)NUM_TIMEPIX_PARAMS, maxBuffers, maxMemory,
+        asynInt64Mask | asynEnumMask,
+        asynInt64Mask | asynEnumMask,
+        ASYN_MULTIDEVICE | ASYN_CANBLOCK,
+        1,
+        priority,
+        stackSize)
+{
     static const char* functionName = "ADTimePix";
 
     /* Initialize GraphicsMagick */
@@ -1894,92 +1825,29 @@ ADTimePix::ADTimePix(const char* portName, const char* serverURL, int maxBuffers
     createParam(ADTimePixExternalReferenceClockString,      asynParamInt32,     &ADTimePixExternalReferenceClock);          
     createParam(ADTimePixLogLevelString,                    asynParamInt32,     &ADTimePixLogLevel);
 
-        // Detector Chips: Chip0
-    createParam(ADTimePixChip0CP_PLLString,             asynParamInt32, &ADTimePixChip0CP_PLL);
-    createParam(ADTimePixChip0DiscS1OFFString,          asynParamInt32, &ADTimePixChip0DiscS1OFF);    
-    createParam(ADTimePixChip0DiscS1ONString,           asynParamInt32, &ADTimePixChip0DiscS1ON);    
-    createParam(ADTimePixChip0DiscS2OFFString,          asynParamInt32, &ADTimePixChip0DiscS2OFF);    
-    createParam(ADTimePixChip0DiscS2ONString,           asynParamInt32, &ADTimePixChip0DiscS2ON);    
-    createParam(ADTimePixChip0IkrumString,              asynParamInt32, &ADTimePixChip0Ikrum);
-    createParam(ADTimePixChip0PixelDACString,           asynParamInt32, &ADTimePixChip0PixelDAC);    
-    createParam(ADTimePixChip0PreampOFFString,          asynParamInt32, &ADTimePixChip0PreampOFF);    
-    createParam(ADTimePixChip0PreampONString,           asynParamInt32, &ADTimePixChip0PreampON);    
-    createParam(ADTimePixChip0TPbufferInString,         asynParamInt32, &ADTimePixChip0TPbufferIn);    
-    createParam(ADTimePixChip0TPbufferOutString,        asynParamInt32, &ADTimePixChip0TPbufferOut);        
-    createParam(ADTimePixChip0PLL_VcntrlString,         asynParamInt32, &ADTimePixChip0PLL_Vcntrl);    
-    createParam(ADTimePixChip0VPreampNCASString,        asynParamInt32, &ADTimePixChip0VPreampNCAS);        
-    createParam(ADTimePixChip0VTPcoarseString,          asynParamInt32, &ADTimePixChip0VTPcoarse);    
-    createParam(ADTimePixChip0VTPfineString,            asynParamInt32, &ADTimePixChip0VTPfine);    
-    createParam(ADTimePixChip0VfbkString,               asynParamInt32, &ADTimePixChip0Vfbk);
-    createParam(ADTimePixChip0VthresholdCoarseString,   asynParamInt32, &ADTimePixChip0VthresholdCoarse);            
-    createParam(ADTimePixChip0VTthresholdFineString,    asynParamInt32, &ADTimePixChip0VTthresholdFine);            
-    createParam(ADTimePixChip0AdjustString,             asynParamInt32, &ADTimePixChip0Adjust);
-    // Detector Chips: Chip1
-    createParam(ADTimePixChip1CP_PLLString,               asynParamInt32, &ADTimePixChip1CP_PLL);
-    createParam(ADTimePixChip1DiscS1OFFString,            asynParamInt32, &ADTimePixChip1DiscS1OFF);    
-    createParam(ADTimePixChip1DiscS1ONString,             asynParamInt32, &ADTimePixChip1DiscS1ON);    
-    createParam(ADTimePixChip1DiscS2OFFString,            asynParamInt32, &ADTimePixChip1DiscS2OFF);    
-    createParam(ADTimePixChip1DiscS2ONString,             asynParamInt32, &ADTimePixChip1DiscS2ON);    
-    createParam(ADTimePixChip1IkrumString,                asynParamInt32, &ADTimePixChip1Ikrum);
-    createParam(ADTimePixChip1PixelDACString,             asynParamInt32, &ADTimePixChip1PixelDAC);    
-    createParam(ADTimePixChip1PreampOFFString,            asynParamInt32, &ADTimePixChip1PreampOFF);    
-    createParam(ADTimePixChip1PreampONString,             asynParamInt32, &ADTimePixChip1PreampON);    
-    createParam(ADTimePixChip1TPbufferInString,           asynParamInt32, &ADTimePixChip1TPbufferIn);    
-    createParam(ADTimePixChip1TPbufferOutString,          asynParamInt32, &ADTimePixChip1TPbufferOut);        
-    createParam(ADTimePixChip1PLL_VcntrlString,           asynParamInt32, &ADTimePixChip1PLL_Vcntrl);    
-    createParam(ADTimePixChip1VPreampNCASString,          asynParamInt32, &ADTimePixChip1VPreampNCAS);        
-    createParam(ADTimePixChip1VTPcoarseString,            asynParamInt32, &ADTimePixChip1VTPcoarse);    
-    createParam(ADTimePixChip1VTPfineString,              asynParamInt32, &ADTimePixChip1VTPfine);    
-    createParam(ADTimePixChip1VfbkString,                 asynParamInt32, &ADTimePixChip1Vfbk);
-    createParam(ADTimePixChip1VthresholdCoarseString,     asynParamInt32, &ADTimePixChip1VthresholdCoarse);    
-    createParam(ADTimePixChip1VTthresholdFineString,      asynParamInt32, &ADTimePixChip1VTthresholdFine);    
-    createParam(ADTimePixChip1AdjustString,               asynParamInt32, &ADTimePixChip1Adjust);
-    // Detector Chips: Chip2
-    createParam(ADTimePixChip2CP_PLLString,                asynParamInt32, &ADTimePixChip2CP_PLL);
-    createParam(ADTimePixChip2DiscS1OFFString,             asynParamInt32, &ADTimePixChip2DiscS1OFF);
-    createParam(ADTimePixChip2DiscS1ONString,              asynParamInt32, &ADTimePixChip2DiscS1ON);
-    createParam(ADTimePixChip2DiscS2OFFString,             asynParamInt32, &ADTimePixChip2DiscS2OFF);
-    createParam(ADTimePixChip2DiscS2ONString,              asynParamInt32, &ADTimePixChip2DiscS2ON);
-    createParam(ADTimePixChip2IkrumString,                 asynParamInt32, &ADTimePixChip2Ikrum);
-    createParam(ADTimePixChip2PixelDACString,              asynParamInt32, &ADTimePixChip2PixelDAC);
-    createParam(ADTimePixChip2PreampOFFString,             asynParamInt32, &ADTimePixChip2PreampOFF);
-    createParam(ADTimePixChip2PreampONString,              asynParamInt32, &ADTimePixChip2PreampON);
-    createParam(ADTimePixChip2TPbufferInString,            asynParamInt32, &ADTimePixChip2TPbufferIn);
-    createParam(ADTimePixChip2TPbufferOutString,           asynParamInt32, &ADTimePixChip2TPbufferOut);
-    createParam(ADTimePixChip2PLL_VcntrlString,            asynParamInt32, &ADTimePixChip2PLL_Vcntrl);
-    createParam(ADTimePixChip2VPreampNCASString,           asynParamInt32, &ADTimePixChip2VPreampNCAS);
-    createParam(ADTimePixChip2VTPcoarseString,             asynParamInt32, &ADTimePixChip2VTPcoarse);
-    createParam(ADTimePixChip2VTPfineString,               asynParamInt32, &ADTimePixChip2VTPfine);
-    createParam(ADTimePixChip2VfbkString,                  asynParamInt32, &ADTimePixChip2Vfbk);
-    createParam(ADTimePixChip2VthresholdCoarseString,      asynParamInt32, &ADTimePixChip2VthresholdCoarse);
-    createParam(ADTimePixChip2VTthresholdFineString,       asynParamInt32, &ADTimePixChip2VTthresholdFine);
-    createParam(ADTimePixChip2AdjustString,                asynParamInt32, &ADTimePixChip2Adjust);     
-    // Detector Chips: Chip3
-    createParam(ADTimePixChip3CP_PLLString,                 asynParamInt32, &ADTimePixChip3CP_PLL);
-    createParam(ADTimePixChip3DiscS1OFFString,              asynParamInt32, &ADTimePixChip3DiscS1OFF);
-    createParam(ADTimePixChip3DiscS1ONString,               asynParamInt32, &ADTimePixChip3DiscS1ON);
-    createParam(ADTimePixChip3DiscS2OFFString,              asynParamInt32, &ADTimePixChip3DiscS2OFF);
-    createParam(ADTimePixChip3DiscS2ONString,               asynParamInt32, &ADTimePixChip3DiscS2ON);
-    createParam(ADTimePixChip3IkrumString,                  asynParamInt32, &ADTimePixChip3Ikrum);
-    createParam(ADTimePixChip3PixelDACString,               asynParamInt32, &ADTimePixChip3PixelDAC);
-    createParam(ADTimePixChip3PreampOFFString,              asynParamInt32, &ADTimePixChip3PreampOFF);
-    createParam(ADTimePixChip3PreampONString,               asynParamInt32, &ADTimePixChip3PreampON);
-    createParam(ADTimePixChip3TPbufferInString,             asynParamInt32, &ADTimePixChip3TPbufferIn);
-    createParam(ADTimePixChip3TPbufferOutString,            asynParamInt32, &ADTimePixChip3TPbufferOut);
-    createParam(ADTimePixChip3PLL_VcntrlString,             asynParamInt32, &ADTimePixChip3PLL_Vcntrl);
-    createParam(ADTimePixChip3VPreampNCASString,            asynParamInt32, &ADTimePixChip3VPreampNCAS);
-    createParam(ADTimePixChip3VTPcoarseString,              asynParamInt32, &ADTimePixChip3VTPcoarse);
-    createParam(ADTimePixChip3VTPfineString,                asynParamInt32, &ADTimePixChip3VTPfine);
-    createParam(ADTimePixChip3VfbkString,                   asynParamInt32, &ADTimePixChip3Vfbk);
-    createParam(ADTimePixChip3VthresholdCoarseString,       asynParamInt32, &ADTimePixChip3VthresholdCoarse);
-    createParam(ADTimePixChip3VTthresholdFineString,        asynParamInt32, &ADTimePixChip3VTthresholdFine);
-    createParam(ADTimePixChip3AdjustString,                 asynParamInt32, &ADTimePixChip3Adjust);
+    // Detector Chips
+    createParam(ADTimePixCP_PLLString,             asynParamInt32, &ADTimePixCP_PLL);
+    createParam(ADTimePixDiscS1OFFString,          asynParamInt32, &ADTimePixDiscS1OFF);
+    createParam(ADTimePixDiscS1ONString,           asynParamInt32, &ADTimePixDiscS1ON);
+    createParam(ADTimePixDiscS2OFFString,          asynParamInt32, &ADTimePixDiscS2OFF);
+    createParam(ADTimePixDiscS2ONString,           asynParamInt32, &ADTimePixDiscS2ON);
+    createParam(ADTimePixIkrumString,              asynParamInt32, &ADTimePixIkrum);
+    createParam(ADTimePixPixelDACString,           asynParamInt32, &ADTimePixPixelDAC);
+    createParam(ADTimePixPreampOFFString,          asynParamInt32, &ADTimePixPreampOFF);
+    createParam(ADTimePixPreampONString,           asynParamInt32, &ADTimePixPreampON);
+    createParam(ADTimePixTPbufferInString,         asynParamInt32, &ADTimePixTPbufferIn);
+    createParam(ADTimePixTPbufferOutString,        asynParamInt32, &ADTimePixTPbufferOut);
+    createParam(ADTimePixPLL_VcntrlString,         asynParamInt32, &ADTimePixPLL_Vcntrl);
+    createParam(ADTimePixVPreampNCASString,        asynParamInt32, &ADTimePixVPreampNCAS);
+    createParam(ADTimePixVTPcoarseString,          asynParamInt32, &ADTimePixVTPcoarse);
+    createParam(ADTimePixVTPfineString,            asynParamInt32, &ADTimePixVTPfine);
+    createParam(ADTimePixVfbkString,               asynParamInt32, &ADTimePixVfbk);
+    createParam(ADTimePixVthresholdCoarseString,   asynParamInt32, &ADTimePixVthresholdCoarse);
+    createParam(ADTimePixVTthresholdFineString,    asynParamInt32, &ADTimePixVTthresholdFine);
+    createParam(ADTimePixAdjustString,             asynParamInt32, &ADTimePixAdjust);
              
     // Detector Chip Layout
-    createParam(ADTimePixChip0LayoutString,               asynParamOctet, &ADTimePixChip0Layout);
-    createParam(ADTimePixChip1LayoutString,               asynParamOctet, &ADTimePixChip1Layout);
-    createParam(ADTimePixChip2LayoutString,               asynParamOctet, &ADTimePixChip2Layout);
-    createParam(ADTimePixChip3LayoutString,               asynParamOctet, &ADTimePixChip3Layout);
+    createParam(ADTimePixLayoutString,               asynParamOctet, &ADTimePixLayout);
 
     // Files BPC, Chip/DACS
     createParam(ADTimePixBPCFilePathString,                asynParamOctet,  &ADTimePixBPCFilePath);            

--- a/tpx3App/src/ADTimePix.h
+++ b/tpx3App/src/ADTimePix.h
@@ -19,6 +19,9 @@
 #define ADTIMEPIX_REVISION     1
 #define ADTIMEPIX_MODIFICATION 0
 
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
 
 // Driver-specific PV string definitions here
 /*                                         String                        asyn interface         access  Description  */
@@ -93,93 +96,29 @@
 #define ADTimePixExternalReferenceClockString   "TPX3_EXT_REF_CLOCK"     // (asynInt32,         r)   ExternalReferenceClock
 #define ADTimePixLogLevelString                 "TPX3_LOG_LEVEL"         // (asynInt32,         r)   LogLevel
 
-    // Detector Chips: Chip0; Chips count from 0-3.
-#define ADTimePixChip0CP_PLLString              "TPX3_CHIP0_CP_PLL"           // (asynInt32,         r)      DACs->Ibias_CP_PLL
-#define ADTimePixChip0DiscS1OFFString           "TPX3_CHIP0_DISCS1OFF"        // (asynInt32,         r)      DACs->Ibias_DiscS1_OFF
-#define ADTimePixChip0DiscS1ONString            "TPX3_CHIP0_DISCS1ON"         // (asynInt32,         r)      DACs->Ibias_DiscS1_ON
-#define ADTimePixChip0DiscS2OFFString           "TPX3_CHIP0_DISCS2OFF"        // (asynInt32,         r)      DACs->Ibias_DiscS2_OFF
-#define ADTimePixChip0DiscS2ONString            "TPX3_CHIP0_DISCS2ON"         // (asynInt32,         r)      DACs->Ibias_DiscS2_ON
-#define ADTimePixChip0IkrumString               "TPX3_CHIP0_IKRUM"            // (asynInt32,         r)      DACs->Ibias_Ikrum
-#define ADTimePixChip0PixelDACString            "TPX3_CHIP0_PIXELDAC"         // (asynInt32,         r)      DACs->Ibias_PixelDAC
-#define ADTimePixChip0PreampOFFString           "TPX3_CHIP0_PREAMPOFF"        // (asynInt32,         r)      DACs->Ibias_Preamp_OFF
-#define ADTimePixChip0PreampONString            "TPX3_CHIP0_PREAMPON"         // (asynInt32,         r)      DACs->Ibias_Preamp_ON
-#define ADTimePixChip0TPbufferInString          "TPX3_CHIP0_TPBUFFERIN"       // (asynInt32,         r)      DACs->Ibias_TPbufferIn
-#define ADTimePixChip0TPbufferOutString         "TPX3_CHIP0_TPBUFFEROUT"      // (asynInt32,         r)      DACs->Ibias_TPbufferOut
-#define ADTimePixChip0PLL_VcntrlString          "TPX3_CHIP0_PLL_VCNTRL"       // (asynInt32,         r)      DACs->PLL_Vcntrl
-#define ADTimePixChip0VPreampNCASString         "TPX3_CHIP0_VPREAMPNCAS"      // (asynInt32,         r)      DACs->VPreamp_NCAS
-#define ADTimePixChip0VTPcoarseString           "TPX3_CHIP0_VTP_COARSE"       // (asynInt32,         r)      DACs->VTP_coarse
-#define ADTimePixChip0VTPfineString             "TPX3_CHIP0_VTP_FINE"         // (asynInt32,         r)      DACs->VTP_fine
-#define ADTimePixChip0VfbkString                "TPX3_CHIP0_VFBK"             // (asynInt32,         r)      DACs->Vfbk
-#define ADTimePixChip0VthresholdCoarseString    "TPX3_CHIP0_VTH_COARSE"       // (asynInt32,         r)      DACs->Vthreshold_coarse
-#define ADTimePixChip0VTthresholdFineString     "TPX3_CHIP0_VTH_FINE"         // (asynInt32,         r)      DACs->Vthreshold_fine
-#define ADTimePixChip0AdjustString              "TPX3_CHIP0_ADJUST"           // (asynInt32,         r)      DACs->Adjust
-    // Detector Chips: Chip1
-#define ADTimePixChip1CP_PLLString              "TPX3_CHIP1_CP_PLL"           // (asynInt32,         r)      DACs->Ibias_CP_PLL
-#define ADTimePixChip1DiscS1OFFString           "TPX3_CHIP1_DISCS1OFF"        // (asynInt32,         r)      DACs->Ibias_DiscS1_OFF
-#define ADTimePixChip1DiscS1ONString            "TPX3_CHIP1_DISCS1ON"         // (asynInt32,         r)      DACs->Ibias_DiscS1_ON
-#define ADTimePixChip1DiscS2OFFString           "TPX3_CHIP1_DISCS2OFF"        // (asynInt32,         r)      DACs->Ibias_DiscS2_OFF
-#define ADTimePixChip1DiscS2ONString            "TPX3_CHIP1_DISCS2ON"         // (asynInt32,         r)      DACs->Ibias_DiscS2_ON
-#define ADTimePixChip1IkrumString               "TPX3_CHIP1_IKRUM"            // (asynInt32,         r)      DACs->Ibias_Ikrum
-#define ADTimePixChip1PixelDACString            "TPX3_CHIP1_PIXELDAC"         // (asynInt32,         r)      DACs->Ibias_PixelDAC
-#define ADTimePixChip1PreampOFFString           "TPX3_CHIP1_PREAMPOFF"        // (asynInt32,         r)      DACs->Ibias_Preamp_OFF
-#define ADTimePixChip1PreampONString            "TPX3_CHIP1_PREAMPON"         // (asynInt32,         r)      DACs->Ibias_Preamp_ON
-#define ADTimePixChip1TPbufferInString          "TPX3_CHIP1_TPBUFFERIN"       // (asynInt32,         r)      DACs->Ibias_TPbufferIn
-#define ADTimePixChip1TPbufferOutString         "TPX3_CHIP1_TPBUFFEROUT"      // (asynInt32,         r)      DACs->Ibias_TPbufferOut
-#define ADTimePixChip1PLL_VcntrlString          "TPX3_CHIP1_PLL_VCNTRL"       // (asynInt32,         r)      DACs->PLL_Vcntrl
-#define ADTimePixChip1VPreampNCASString         "TPX3_CHIP1_VPREAMPNCAS"      // (asynInt32,         r)      DACs->VPreamp_NCAS
-#define ADTimePixChip1VTPcoarseString           "TPX3_CHIP1_VTP_COARSE"       // (asynInt32,         r)      DACs->VTP_coarse
-#define ADTimePixChip1VTPfineString             "TPX3_CHIP1_VTP_FINE"         // (asynInt32,         r)      DACs->VTP_fine
-#define ADTimePixChip1VfbkString                "TPX3_CHIP1_VFBK"             // (asynInt32,         r)      DACs->Vfbk
-#define ADTimePixChip1VthresholdCoarseString    "TPX3_CHIP1_VTH_COARSE"       // (asynInt32,         r)      DACs->Vthreshold_coarse
-#define ADTimePixChip1VTthresholdFineString     "TPX3_CHIP1_VTH_FINE"         // (asynInt32,         r)      DACs->Vthreshold_fine
-#define ADTimePixChip1AdjustString              "TPX3_CHIP1_ADJUST"           // (asynInt32,         r)      DACs->Adjust
-    // Detector Chips: Chip2
-#define ADTimePixChip2CP_PLLString              "TPX3_CHIP2_CP_PLL"           // (asynInt32,         r)      DACs->Ibias_CP_PLL
-#define ADTimePixChip2DiscS1OFFString           "TPX3_CHIP2_DISCS1OFF"        // (asynInt32,         r)      DACs->Ibias_DiscS1_OFF
-#define ADTimePixChip2DiscS1ONString            "TPX3_CHIP2_DISCS1ON"         // (asynInt32,         r)      DACs->Ibias_DiscS1_ON
-#define ADTimePixChip2DiscS2OFFString           "TPX3_CHIP2_DISCS2OFF"        // (asynInt32,         r)      DACs->Ibias_DiscS2_OFF
-#define ADTimePixChip2DiscS2ONString            "TPX3_CHIP2_DISCS2ON"         // (asynInt32,         r)      DACs->Ibias_DiscS2_ON
-#define ADTimePixChip2IkrumString               "TPX3_CHIP2_IKRUM"            // (asynInt32,         r)      DACs->Ibias_Ikrum
-#define ADTimePixChip2PixelDACString            "TPX3_CHIP2_PIXELDAC"         // (asynInt32,         r)      DACs->Ibias_PixelDAC
-#define ADTimePixChip2PreampOFFString           "TPX3_CHIP2_PREAMPOFF"        // (asynInt32,         r)      DACs->Ibias_Preamp_OFF
-#define ADTimePixChip2PreampONString            "TPX3_CHIP2_PREAMPON"         // (asynInt32,         r)      DACs->Ibias_Preamp_ON
-#define ADTimePixChip2TPbufferInString          "TPX3_CHIP2_TPBUFFERIN"       // (asynInt32,         r)      DACs->Ibias_TPbufferIn
-#define ADTimePixChip2TPbufferOutString         "TPX3_CHIP2_TPBUFFEROUT"      // (asynInt32,         r)      DACs->Ibias_TPbufferOut
-#define ADTimePixChip2PLL_VcntrlString          "TPX3_CHIP2_PLL_VCNTRL"       // (asynInt32,         r)      DACs->PLL_Vcntrl
-#define ADTimePixChip2VPreampNCASString         "TPX3_CHIP2_VPREAMPNCAS"      // (asynInt32,         r)      DACs->VPreamp_NCAS
-#define ADTimePixChip2VTPcoarseString           "TPX3_CHIP2_VTP_COARSE"       // (asynInt32,         r)      DACs->VTP_coarse
-#define ADTimePixChip2VTPfineString             "TPX3_CHIP2_VTP_FINE"         // (asynInt32,         r)      DACs->VTP_fine
-#define ADTimePixChip2VfbkString                "TPX3_CHIP2_VFBK"             // (asynInt32,         r)      DACs->Vfbk
-#define ADTimePixChip2VthresholdCoarseString    "TPX3_CHIP2_VTH_COARSE"       // (asynInt32,         r)      DACs->Vthreshold_coarse
-#define ADTimePixChip2VTthresholdFineString     "TPX3_CHIP2_VTH_FINE"         // (asynInt32,         r)      DACs->Vthreshold_fine
-#define ADTimePixChip2AdjustString              "TPX3_CHIP2_ADJUST"           // (asynInt32,         r)      DACs->Adjust
-    // Detector Chips: Chip3
-#define ADTimePixChip3CP_PLLString              "TPX3_CHIP3_CP_PLL"           // (asynInt32,         r)      DACs->Ibias_CP_PLL
-#define ADTimePixChip3DiscS1OFFString           "TPX3_CHIP3_DISCS1OFF"        // (asynInt32,         r)      DACs->Ibias_DiscS1_OFF
-#define ADTimePixChip3DiscS1ONString            "TPX3_CHIP3_DISCS1ON"         // (asynInt32,         r)      DACs->Ibias_DiscS1_ON
-#define ADTimePixChip3DiscS2OFFString           "TPX3_CHIP3_DISCS2OFF"        // (asynInt32,         r)      DACs->Ibias_DiscS2_OFF
-#define ADTimePixChip3DiscS2ONString            "TPX3_CHIP3_DISCS2ON"         // (asynInt32,         r)      DACs->Ibias_DiscS2_ON
-#define ADTimePixChip3IkrumString               "TPX3_CHIP3_IKRUM"            // (asynInt32,         r)      DACs->Ibias_Ikrum
-#define ADTimePixChip3PixelDACString            "TPX3_CHIP3_PIXELDAC"         // (asynInt32,         r)      DACs->Ibias_PixelDAC
-#define ADTimePixChip3PreampOFFString           "TPX3_CHIP3_PREAMPOFF"        // (asynInt32,         r)      DACs->Ibias_Preamp_OFF
-#define ADTimePixChip3PreampONString            "TPX3_CHIP3_PREAMPON"         // (asynInt32,         r)      DACs->Ibias_Preamp_ON
-#define ADTimePixChip3TPbufferInString          "TPX3_CHIP3_TPBUFFERIN"       // (asynInt32,         r)      DACs->Ibias_TPbufferIn
-#define ADTimePixChip3TPbufferOutString         "TPX3_CHIP3_TPBUFFEROUT"      // (asynInt32,         r)      DACs->Ibias_TPbufferOut
-#define ADTimePixChip3PLL_VcntrlString          "TPX3_CHIP3_PLL_VCNTRL"       // (asynInt32,         r)      DACs->PLL_Vcntrl
-#define ADTimePixChip3VPreampNCASString         "TPX3_CHIP3_VPREAMPNCAS"      // (asynInt32,         r)      DACs->VPreamp_NCAS
-#define ADTimePixChip3VTPcoarseString           "TPX3_CHIP3_VTP_COARSE"       // (asynInt32,         r)      DACs->VTP_coarse
-#define ADTimePixChip3VTPfineString             "TPX3_CHIP3_VTP_FINE"         // (asynInt32,         r)      DACs->VTP_fine
-#define ADTimePixChip3VfbkString                "TPX3_CHIP3_VFBK"             // (asynInt32,         r)      DACs->Vfbk
-#define ADTimePixChip3VthresholdCoarseString    "TPX3_CHIP3_VTH_COARSE"       // (asynInt32,         r)      DACs->Vthreshold_coarse
-#define ADTimePixChip3VTthresholdFineString     "TPX3_CHIP3_VTH_FINE"         // (asynInt32,         r)      DACs->Vthreshold_fine
-#define ADTimePixChip3AdjustString              "TPX3_CHIP3_ADJUST"           // (asynInt32,         r)      DACs->Adjust
-
-    // Chip Layout
+// Detector Chips: Chip0; Chips count from 0-3. The index come from ADDR parameter
+#define ADTimePixCP_PLLString              "TPX3_CP_PLL"           // (asynInt32,         r)      DACs->Ibias_CP_PLL
+#define ADTimePixDiscS1OFFString           "TPX3_DISCS1OFF"        // (asynInt32,         r)      DACs->Ibias_DiscS1_OFF
+#define ADTimePixDiscS1ONString            "TPX3_DISCS1ON"         // (asynInt32,         r)      DACs->Ibias_DiscS1_ON
+#define ADTimePixDiscS2OFFString           "TPX3_DISCS2OFF"        // (asynInt32,         r)      DACs->Ibias_DiscS2_OFF
+#define ADTimePixDiscS2ONString            "TPX3_DISCS2ON"         // (asynInt32,         r)      DACs->Ibias_DiscS2_ON
+#define ADTimePixIkrumString               "TPX3_IKRUM"            // (asynInt32,         r)      DACs->Ibias_Ikrum
+#define ADTimePixPixelDACString            "TPX3_PIXELDAC"         // (asynInt32,         r)      DACs->Ibias_PixelDAC
+#define ADTimePixPreampOFFString           "TPX3_PREAMPOFF"        // (asynInt32,         r)      DACs->Ibias_Preamp_OFF
+#define ADTimePixPreampONString            "TPX3_PREAMPON"         // (asynInt32,         r)      DACs->Ibias_Preamp_ON
+#define ADTimePixTPbufferInString          "TPX3_TPBUFFERIN"       // (asynInt32,         r)      DACs->Ibias_TPbufferIn
+#define ADTimePixTPbufferOutString         "TPX3_TPBUFFEROUT"      // (asynInt32,         r)      DACs->Ibias_TPbufferOut
+#define ADTimePixPLL_VcntrlString          "TPX3_PLL_VCNTRL"       // (asynInt32,         r)      DACs->PLL_Vcntrl
+#define ADTimePixVPreampNCASString         "TPX3_VPREAMPNCAS"      // (asynInt32,         r)      DACs->VPreamp_NCAS
+#define ADTimePixVTPcoarseString           "TPX3_VTP_COARSE"       // (asynInt32,         r)      DACs->VTP_coarse
+#define ADTimePixVTPfineString             "TPX3_VTP_FINE"         // (asynInt32,         r)      DACs->VTP_fine
+#define ADTimePixVfbkString                "TPX3_VFBK"             // (asynInt32,         r)      DACs->Vfbk
+#define ADTimePixVthresholdCoarseString    "TPX3_VTH_COARSE"       // (asynInt32,         r)      DACs->Vthreshold_coarse
+#define ADTimePixVTthresholdFineString     "TPX3_VTH_FINE"         // (asynInt32,         r)      DACs->Vthreshold_fine
+#define ADTimePixAdjustString              "TPX3_ADJUST"           // (asynInt32,         r)      DACs->Adjust
+// Chip Layout
 #define ADTimePixDetectorOrientationString  "TPX3_DET_ORIENTATION"            // (asynOctet,         r)      DetectorOrientation, in Detector/Layout since 3.0.0
-#define ADTimePixChip0LayoutString          "TPX3_CHIP0_LAYTOUT"              // (asynOctet,         r)      Chip 0 layout
-#define ADTimePixChip1LayoutString          "TPX3_CHIP1_LAYTOUT"              // (asynOctet,         r)      Chip 1 layout
-#define ADTimePixChip2LayoutString          "TPX3_CHIP2_LAYTOUT"              // (asynOctet,         r)      Chip 2 layout
-#define ADTimePixChip3LayoutString          "TPX3_CHIP3_LAYTOUT"              // (asynOctet,         r)      Chip 3 layout
+#define ADTimePixLayoutString               "TPX3_LAYTOUT"              // (asynOctet,         r)      Chip layout
 
     // Absolute path to the binary pixel configuration, absolute path to the text chips configuration
 #define ADTimePixBPCFilePathString          "BPC_FILE_PATH"             /**< (asynOctet,    r/w) The file path Binary Pixel Configuration */
@@ -392,93 +331,30 @@ class ADTimePix : ADDriver{
         int ADTimePixExternalReferenceClock;   
         int ADTimePixLogLevel;                 
          
-             // Detector Chips: Chip0
-        int ADTimePixChip0CP_PLL;              
-        int ADTimePixChip0DiscS1OFF;           
-        int ADTimePixChip0DiscS1ON;            
-        int ADTimePixChip0DiscS2OFF;           
-        int ADTimePixChip0DiscS2ON;            
-        int ADTimePixChip0Ikrum;               
-        int ADTimePixChip0PixelDAC;            
-        int ADTimePixChip0PreampOFF;           
-        int ADTimePixChip0PreampON;            
-        int ADTimePixChip0TPbufferIn;          
-        int ADTimePixChip0TPbufferOut;         
-        int ADTimePixChip0PLL_Vcntrl;          
-        int ADTimePixChip0VPreampNCAS;         
-        int ADTimePixChip0VTPcoarse;           
-        int ADTimePixChip0VTPfine;             
-        int ADTimePixChip0Vfbk;                
-        int ADTimePixChip0VthresholdCoarse;    
-        int ADTimePixChip0VTthresholdFine;     
-        int ADTimePixChip0Adjust;              
-             // Detector Chips: Chip1
-        int ADTimePixChip1CP_PLL;              
-        int ADTimePixChip1DiscS1OFF;           
-        int ADTimePixChip1DiscS1ON;            
-        int ADTimePixChip1DiscS2OFF;           
-        int ADTimePixChip1DiscS2ON;            
-        int ADTimePixChip1Ikrum;               
-        int ADTimePixChip1PixelDAC;            
-        int ADTimePixChip1PreampOFF;           
-        int ADTimePixChip1PreampON;            
-        int ADTimePixChip1TPbufferIn;          
-        int ADTimePixChip1TPbufferOut;         
-        int ADTimePixChip1PLL_Vcntrl;          
-        int ADTimePixChip1VPreampNCAS;         
-        int ADTimePixChip1VTPcoarse;           
-        int ADTimePixChip1VTPfine;             
-        int ADTimePixChip1Vfbk;                
-        int ADTimePixChip1VthresholdCoarse;    
-        int ADTimePixChip1VTthresholdFine;     
-        int ADTimePixChip1Adjust;              
-             // Detector Chips: Chip2
-        int ADTimePixChip2CP_PLL;              
-        int ADTimePixChip2DiscS1OFF;           
-        int ADTimePixChip2DiscS1ON;            
-        int ADTimePixChip2DiscS2OFF;           
-        int ADTimePixChip2DiscS2ON;            
-        int ADTimePixChip2Ikrum;               
-        int ADTimePixChip2PixelDAC;           
-        int ADTimePixChip2PreampOFF;           
-        int ADTimePixChip2PreampON;            
-        int ADTimePixChip2TPbufferIn;          
-        int ADTimePixChip2TPbufferOut;         
-        int ADTimePixChip2PLL_Vcntrl;          
-        int ADTimePixChip2VPreampNCAS;         
-        int ADTimePixChip2VTPcoarse;           
-        int ADTimePixChip2VTPfine;             
-        int ADTimePixChip2Vfbk;                
-        int ADTimePixChip2VthresholdCoarse;    
-        int ADTimePixChip2VTthresholdFine;     
-        int ADTimePixChip2Adjust;              
-             // Detector Chips: Chip3
-        int ADTimePixChip3CP_PLL;
-        int ADTimePixChip3DiscS1OFF;
-        int ADTimePixChip3DiscS1ON;
-        int ADTimePixChip3DiscS2OFF;
-        int ADTimePixChip3DiscS2ON;
-        int ADTimePixChip3Ikrum;
-        int ADTimePixChip3PixelDAC;
-        int ADTimePixChip3PreampOFF;
-        int ADTimePixChip3PreampON;
-        int ADTimePixChip3TPbufferIn;
-        int ADTimePixChip3TPbufferOut;
-        int ADTimePixChip3PLL_Vcntrl;
-        int ADTimePixChip3VPreampNCAS;
-        int ADTimePixChip3VTPcoarse;
-        int ADTimePixChip3VTPfine;
-        int ADTimePixChip3Vfbk;
-        int ADTimePixChip3VthresholdCoarse;
-        int ADTimePixChip3VTthresholdFine;
-        int ADTimePixChip3Adjust;
+        // Detector Chips
+        int ADTimePixCP_PLL;
+        int ADTimePixDiscS1OFF;
+        int ADTimePixDiscS1ON;
+        int ADTimePixDiscS2OFF;
+        int ADTimePixDiscS2ON;
+        int ADTimePixIkrum;
+        int ADTimePixPixelDAC;
+        int ADTimePixPreampOFF;
+        int ADTimePixPreampON;
+        int ADTimePixTPbufferIn;
+        int ADTimePixTPbufferOut;
+        int ADTimePixPLL_Vcntrl;
+        int ADTimePixVPreampNCAS;
+        int ADTimePixVTPcoarse;
+        int ADTimePixVTPfine;
+        int ADTimePixVfbk;
+        int ADTimePixVthresholdCoarse;
+        int ADTimePixVTthresholdFine;
+        int ADTimePixAdjust;
             
-            //  Detector Chip layout
+        // Detector Chip layout
         int ADTimePixDetectorOrientation;
-        int ADTimePixChip0Layout;
-        int ADTimePixChip1Layout;
-        int ADTimePixChip2Layout;
-        int ADTimePixChip3Layout;    
+        int ADTimePixLayout;
 
             // Files BPC, Chip/DACS
         int ADTimePixBPCFilePath;          
@@ -627,6 +503,7 @@ class ADTimePix : ADDriver{
         bool checkPath(std::string &filePath);
         asynStatus uploadBPC();
         asynStatus uploadDACS();
+        asynStatus fecthDacs(json &data, int chip);
         asynStatus readImage();
         asynStatus fileWriter();
 

--- a/tpx3App/src/ADTimePix.h
+++ b/tpx3App/src/ADTimePix.h
@@ -114,7 +114,7 @@ using json = nlohmann::json;
 #define ADTimePixVTPfineString             "TPX3_VTP_FINE"         // (asynInt32,         r)      DACs->VTP_fine
 #define ADTimePixVfbkString                "TPX3_VFBK"             // (asynInt32,         r)      DACs->Vfbk
 #define ADTimePixVthresholdCoarseString    "TPX3_VTH_COARSE"       // (asynInt32,         r)      DACs->Vthreshold_coarse
-#define ADTimePixVTthresholdFineString     "TPX3_VTH_FINE"         // (asynInt32,         r)      DACs->Vthreshold_fine
+#define ADTimePixVthresholdFineString      "TPX3_VTH_FINE"         // (asynInt32,         r)      DACs->Vthreshold_fine
 #define ADTimePixAdjustString              "TPX3_ADJUST"           // (asynInt32,         r)      DACs->Adjust
 // Chip Layout
 #define ADTimePixDetectorOrientationString  "TPX3_DET_ORIENTATION"            // (asynOctet,         r)      DetectorOrientation, in Detector/Layout since 3.0.0
@@ -349,7 +349,7 @@ class ADTimePix : ADDriver{
         int ADTimePixVTPfine;
         int ADTimePixVfbk;
         int ADTimePixVthresholdCoarse;
-        int ADTimePixVTthresholdFine;
+        int ADTimePixVthresholdFine;
         int ADTimePixAdjust;
             
         // Detector Chip layout
@@ -503,6 +503,7 @@ class ADTimePix : ADDriver{
         bool checkPath(std::string &filePath);
         asynStatus uploadBPC();
         asynStatus uploadDACS();
+        asynStatus writeDac(int chip, const std::string &dac, int value);
         asynStatus fecthDacs(json &data, int chip);
         asynStatus readImage();
         asynStatus fileWriter();


### PR DESCRIPTION
Tested on a 1 chip TimePix3 at European Spallation Source. 
Includes the following changes (see commits)
- Fix RawStream PV type
- Initialize GraphicsMagick on class constructor
- Refactor DACs code to use asyn multidevice mechanism, using different asyn address for the chips
- Add PVs to write on Threshold DACs

Ping @kgofron 